### PR TITLE
Replace hard coded dashboard + clickable posters

### DIFF
--- a/app/assets/stylesheets/components/_dashboard_event.scss
+++ b/app/assets/stylesheets/components/_dashboard_event.scss
@@ -1,7 +1,5 @@
 .event-container {
   height: 160px;
-  // background-color: #A2A0A2;
-  background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('https://images.pexels.com/photos/1763075/pexels-photo-1763075.jpeg') center;
   padding: 8px;
   display: flex;
   justify-content: space-between;
@@ -13,15 +11,22 @@
     flex-direction: column;
     justify-content: space-between;
 
+    h3 {
+      font-weight: bold;
+    }
+
     p {
       margin: 0;
       padding: 0;
+      font-size: 24px;
     }
   }
 
   .right {
     margin: 0;
     padding: 0;
+    align-self: flex-end;
+    font-size: 16px;
 
     p {
       margin: 0;

--- a/app/assets/stylesheets/components/_dashboard_task.scss
+++ b/app/assets/stylesheets/components/_dashboard_task.scss
@@ -7,6 +7,10 @@
   padding: 8px;
   padding-right: 0;
 
+  &:hover {
+    opacity: 0.7;
+  }
+
   .task-checkbox {
     overflow: hidden;
     margin: 0;
@@ -27,6 +31,10 @@
     min-width: 180px;
   }
 
+  .task-event-link-container {
+    text-decoration: none;
+  }
+
   .task-event {
     height: 64px;
     // background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('https://images.pexels.com/photos/1763075/pexels-photo-1763075.jpeg') center;
@@ -39,6 +47,7 @@
 
     h5 {
       align-self: center;
+      color: #ECECEC;
     }
   }
 

--- a/app/assets/stylesheets/components/_dashboard_task.scss
+++ b/app/assets/stylesheets/components/_dashboard_task.scss
@@ -1,7 +1,6 @@
 .task-container {
   height: 64px;
   display: flex;
-  // justify-content: space-between;
   align-items: center;
   color: #ECECEC;
   border: 1px solid #1F2022;
@@ -30,12 +29,10 @@
 
   .task-event {
     height: 64px;
-    // background-color: #A2A0A2;
-    background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('https://images.pexels.com/photos/1763075/pexels-photo-1763075.jpeg') center;
+    // background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('https://images.pexels.com/photos/1763075/pexels-photo-1763075.jpeg') center;
     width: 240px;
     margin: 0;
     padding: 0;
-    // text-align: center;
     display: flex;
     justify-content: center;
     flex-shrink: 0;

--- a/app/assets/stylesheets/components/_dashboard_task.scss
+++ b/app/assets/stylesheets/components/_dashboard_task.scss
@@ -1,7 +1,7 @@
 .task-container {
   height: 64px;
   display: flex;
-  justify-content: space-between;
+  // justify-content: space-between;
   align-items: center;
   color: #ECECEC;
   border: 1px solid #1F2022;
@@ -12,6 +12,7 @@
     overflow: hidden;
     margin: 0;
     max-width: 480px;
+    flex-grow: 1;
 
     .task-description {
       color: #A2A0A2;
@@ -22,6 +23,9 @@
   .task-due-date {
     font-size: 12px;
     margin: 0;
+    text-align: right;
+    flex-grow: 1;
+    min-width: 180px;
   }
 
   .task-event {
@@ -34,6 +38,7 @@
     // text-align: center;
     display: flex;
     justify-content: center;
+    flex-shrink: 0;
 
     h5 {
       align-self: center;

--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -20,12 +20,23 @@
     }
   }
 
+  .event-link-container {
+    text-decoration: none;
+
+    &:hover {
+      opacity: 0.7;
+    }
+  }
+
   .dashboard-events-container {
     height: 800px;
     background-color: #2A2B2D;
     overflow: hidden;
 
     .dashboard-events-headers {
+      display: flex;
+      justify-content: space-between;
+
 
       h3 {
         color: #ECECEC;

--- a/app/views/users/_dashboard_event.html.erb
+++ b/app/views/users/_dashboard_event.html.erb
@@ -1,10 +1,10 @@
-<div class="event-container m-3">
+<div class="event-container m-3" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= event.poster_url %>') center;">
   <div class="left">
     <h3><%= event.name %></h3>
     <p><%= event.location %></p>
   </div>
   <div class="right">
-    <p><%= event.start_date %></p>
-    <p>23:00 - 05:00 JST</p>
+    <p><%= event.start_date.strftime('%A %B %d, %Y') %></p>
+    <p><%= event.start_date.localtime.strftime('%H:%M')%> - <%= event.end_date.localtime.strftime('%H:%M %Z') %></p>
   </div>
 </div>

--- a/app/views/users/_dashboard_event.html.erb
+++ b/app/views/users/_dashboard_event.html.erb
@@ -1,10 +1,12 @@
-<div class="event-container m-3" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= event.poster_url %>') center;">
-  <div class="left">
-    <h3><%= event.name %></h3>
-    <p><%= event.location %></p>
+<%= link_to event_path(event), class: "event-link-container" do %>
+  <div class="event-container m-3" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= event.poster_url %>') center;">
+    <div class="left">
+      <h3><%= event.name %></h3>
+      <p><%= event.location %></p>
+    </div>
+    <div class="right">
+      <p><%= event.start_date.strftime('%A %B %d, %Y') %></p>
+      <p><%= event.start_date.localtime.strftime('%H:%M')%> - <%= event.end_date.localtime.strftime('%H:%M %Z') %></p>
+    </div>
   </div>
-  <div class="right">
-    <p><%= event.start_date.strftime('%A %B %d, %Y') %></p>
-    <p><%= event.start_date.localtime.strftime('%H:%M')%> - <%= event.end_date.localtime.strftime('%H:%M %Z') %></p>
-  </div>
-</div>
+<% end %>

--- a/app/views/users/_dashboard_task.html.erb
+++ b/app/views/users/_dashboard_task.html.erb
@@ -2,7 +2,7 @@
   <div class="form-check task-checkbox">
     <input type="checkbox" class="form-check-input" value="" id="flexCheckDefault">
     <label for="flexCheckDefault" class="form-check-label text-truncate" value=""><%= task.name %></label>
-    <p class="task-description text-truncate">Lorem ipsum dolor sit amet consectetur adipisicing elit. Nulla cum cumque.Lorem ipsum dolor sit amet consectetur adipisicing elit. Nulla cum cumque.Lorem ipsum dolor sit amet consectetur adipisicing elit. Nulla cum cumque.Lorem ipsum dolor sit amet consectetur adipisicing elit. Nulla cum cumque.</p>
+    <p class="task-description text-truncate"><%= task.description %></p>
   </div>
   <div class="task-due-date px-3">
     <p>Wednesday, August 24th</p>

--- a/app/views/users/_dashboard_task.html.erb
+++ b/app/views/users/_dashboard_task.html.erb
@@ -5,8 +5,10 @@
     <p class="task-description text-truncate"><%= task.description %></p>
   </div>
   <div class="task-due-date px-3">
-    <p>Wednesday, August 24th</p>
-    <p>20:00 JST</p>
+    <% if task.end %>
+      <p><%= task.end.strftime('%A %B %d, %Y') %></p>
+      <p><%= task.end.strftime('%H:%M %Z') %> </p>
+    <% end %>
   </div>
   <div class="container task-event">
     <h5><%= task.event.name %></h5>

--- a/app/views/users/_dashboard_task.html.erb
+++ b/app/views/users/_dashboard_task.html.erb
@@ -10,7 +10,7 @@
       <p><%= task.end.strftime('%H:%M %Z') %> </p>
     <% end %>
   </div>
-  <div class="container task-event">
+  <div class="container task-event" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= task.event.poster_url %>;') center;">
     <h5><%= task.event.name %></h5>
   </div>
 </div>

--- a/app/views/users/_dashboard_task.html.erb
+++ b/app/views/users/_dashboard_task.html.erb
@@ -10,7 +10,9 @@
       <p><%= task.end.strftime('%H:%M %Z') %> </p>
     <% end %>
   </div>
-  <div class="container task-event" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= task.event.poster_url %>;') center;">
-    <h5><%= task.event.name %></h5>
-  </div>
+  <%= link_to event_path(task.event), class: "text-decoration-none" do %>
+    <div class="container task-event" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= task.event.poster_url %>;') center;">
+      <h5><%= task.event.name %></h5>
+    </div>
+  <% end %>
 </div>

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -13,8 +13,9 @@
   </div>
   <div class="row mx-3 justify-content-center">
     <div class="dashboard-events-container col-10 p-3">
-      <div class="dashboard-events-headers ps-3">
+      <div class="dashboard-events-headers px-3">
         <h3>Events</h3>
+        <%= link_to 'Create Event', new_event_path, class: "btn btn-primary" %>
       </div>
       <div class="dashboard-events-inner-container">
         <% @events.each do |event| %>


### PR DESCRIPTION
Replaced all the hard coded dashboard info with actual info from events.
Added hover effects for tasks and events.
Added clickable links to each of the event posters that take you to that event show page.

<img width="1423" alt="Screen Shot 2022-08-24 at 17 56 33" src="https://user-images.githubusercontent.com/76161172/186376039-6ac8e65e-7532-4bda-999e-d9aa621154d6.png">
<img width="1423" alt="Screen Shot 2022-08-24 at 17 56 48" src="https://user-images.githubusercontent.com/76161172/186376113-e066694c-4141-458f-aa38-4a81eb1b79dc.png">
