### PR TITLE
Dashboard mark task as done

### DIFF
--- a/app/assets/stylesheets/components/_dashboard_task.scss
+++ b/app/assets/stylesheets/components/_dashboard_task.scss
@@ -9,7 +9,7 @@
   justify-content: space-between;
 
   &:hover {
-    opacity: 0.7;
+    filter: brightness(150%);
   }
 
   .task-checkbox {

--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -15,7 +15,7 @@
         color: #ECECEC;
 
         .dashboard-tasks-count {
-          font-size: 0.8em;
+          font-size: 0.6em;
         }
       }
     }
@@ -51,6 +51,9 @@
         color: #ECECEC;
         flex-grow: 1;
 
+        .dashboard-events-count {
+          font-size: 0.6em;
+        }
       }
 
 

--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -30,7 +30,7 @@
     text-decoration: none;
 
     &:hover {
-      opacity: 0.7;
+      filter: brightness(150%);
     }
   }
 

--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -13,6 +13,10 @@
 
       h2 {
         color: #ECECEC;
+
+        .dashboard-tasks-count {
+          font-size: 0.8em;
+        }
       }
     }
 
@@ -46,7 +50,10 @@
       h2 {
         color: #ECECEC;
         flex-grow: 1;
+
       }
+
+
     }
 
     .dashboard-events-inner-container {

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -27,7 +27,18 @@ class TasksController < ApplicationController
   def update
     @task = Task.find(params[:id])
     authorize @task
-    @task.update!(set_task_params)
+    if set_task_params[:done] == "1"
+      @task.status = "done"
+    else
+      @task.status = "pending"
+    end
+    # raise
+    respond_to do |format|
+      if @task.update!(set_task_params)
+        format.html { redirect_to dashboard_path}
+        format.json
+      end
+    end
     # keep working
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
     authorize @user
     if user_signed_in?
       @events = policy_scope(Event).order(start_date: :asc)
-      @tasks = policy_scope(Task).order(end: :asc)
+      @tasks = policy_scope(Task).where(done: false).order(end: :asc)
 
       # Scope your query to the dates being shown:
       start_date = params.fetch(:start_date, Date.today).to_date

--- a/app/javascript/controllers/dashboard_mark_task_as_done_controller.js
+++ b/app/javascript/controllers/dashboard_mark_task_as_done_controller.js
@@ -2,30 +2,17 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="dashboard-mark-task-as-done"
 export default class extends Controller {
-  static targets = ["input", "status"]
+  static targets = ["forms", "status"]
 
   connect() {
     // console.log("Hello from the 'dashboard-mark-task-as-done' controller!");
-    // console.log(this.inputTarget);
+    console.log(this.formsTargets);
     // console.log(this.statusTarget);
-  }
-
-  markAsDone(event) {
-    event.preventDefault()
-    console.log(this.inputTarget.action);
-
-
-    // url = this.inputTarget.action;
-    // options = {
-    //   method: 'PATCH',
-    //   header: { "Accept": 'text/html' },
-    //   body: new FormData(this.formTarget)
-    // }
-
-    // fetch(url, options)
-    //   .then(response => response.json())
-    //   .then((data) => {
-    //     console.log(data);
-    //   })
+    this.formsTargets.forEach(form => {
+      console.log(form);
+      form.addEventListener("change", function (event) {
+        event.currentTarget.submit()
+      })
+    })
   }
 }

--- a/app/javascript/controllers/dashboard_mark_task_as_done_controller.js
+++ b/app/javascript/controllers/dashboard_mark_task_as_done_controller.js
@@ -2,17 +2,28 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="dashboard-mark-task-as-done"
 export default class extends Controller {
-  static targets = ["status"]
+  static targets = ["form", "status"]
 
   connect() {
-    console.log("Hello from the 'dashboard-mark-task-as-done' controller!");
+    // console.log("Hello from the 'dashboard-mark-task-as-done' controller!");
+    // console.log(this.formTarget);
+    // console.log(this.statusTarget);
   }
 
-  markAsDone() {
-    console.log("Changed!");
+  markAsDone(event) {
+    event.preventDefault()
+    console.log(this.formTarget.action);
+    // url = this.formTarget.action;
+    // options = {
+    //   method: 'PATCH',
+    //   header: { "Accept": 'text/html' },
+    //   body: new FormData(this.formTarget)
+    // }
 
-    console.log(this.statusTarget);
-
-
+    // fetch(url, options)
+    //   .then(response => response.json())
+    //   .then((data) => {
+    //     console.log(data);
+    //   })
   }
 }

--- a/app/javascript/controllers/dashboard_mark_task_as_done_controller.js
+++ b/app/javascript/controllers/dashboard_mark_task_as_done_controller.js
@@ -2,18 +2,20 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="dashboard-mark-task-as-done"
 export default class extends Controller {
-  static targets = ["form", "status"]
+  static targets = ["input", "status"]
 
   connect() {
     // console.log("Hello from the 'dashboard-mark-task-as-done' controller!");
-    // console.log(this.formTarget);
+    // console.log(this.inputTarget);
     // console.log(this.statusTarget);
   }
 
   markAsDone(event) {
     event.preventDefault()
-    console.log(this.formTarget.action);
-    // url = this.formTarget.action;
+    console.log(this.inputTarget.action);
+
+
+    // url = this.inputTarget.action;
     // options = {
     //   method: 'PATCH',
     //   header: { "Accept": 'text/html' },

--- a/app/javascript/controllers/dashboard_mark_task_as_done_controller.js
+++ b/app/javascript/controllers/dashboard_mark_task_as_done_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="dashboard-mark-task-as-done"
+export default class extends Controller {
+  static targets = ["status"]
+
+  connect() {
+    console.log("Hello from the 'dashboard-mark-task-as-done' controller!");
+  }
+
+  markAsDone() {
+    console.log("Changed!");
+
+    console.log(this.statusTarget);
+
+
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import CountdownController from "./countdown_controller"
 application.register("countdown", CountdownController)
 
+import DashboardMarkTaskAsDoneController from "./dashboard_mark_task_as_done_controller"
+application.register("dashboard-mark-task-as-done", DashboardMarkTaskAsDoneController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/users/_dashboard_task.html.erb
+++ b/app/views/users/_dashboard_task.html.erb
@@ -2,8 +2,8 @@
   <div class="form-check task-checkbox">
     <%# <input type="checkbox" class="form-check-input" value="" id="flexCheckDefault" data-action="change->dashboard-mark-task-as-done#markAsDone"> %>
     <%# <label for="flexCheckDefault" class="form-check-label text-truncate" value=""><%= task.name %>
-    <%= simple_form_for(task, data: { action: "change->dashboard-mark-task-as-done#markAsDone"}) do |f| %>
-      <%= f.input :done, label: task.name, class: "form-check-input mb-0", data: { dashboard_mark_task_as_done_target:"input" } %>
+    <%= simple_form_for(task, remote: true, data: {dashboard_mark_task_as_done_target:"forms"}) do |f| %>
+      <%= f.input :done, label: task.name, class: "form-check-input mb-0" %>
     <% end %>
     <p class="task-description text-truncate"><%= task.description %></p>
   </div>

--- a/app/views/users/_dashboard_task.html.erb
+++ b/app/views/users/_dashboard_task.html.erb
@@ -1,7 +1,10 @@
 <div class="task-container m-3 ">
   <div class="form-check task-checkbox">
-    <input type="checkbox" class="form-check-input" value="" id="flexCheckDefault" data-action="change->dashboard-mark-task-as-done#markAsDone">
-    <label for="flexCheckDefault" class="form-check-label text-truncate" value=""><%= task.name %></label>
+    <%# <input type="checkbox" class="form-check-input" value="" id="flexCheckDefault" data-action="change->dashboard-mark-task-as-done#markAsDone"> %>
+    <%# <label for="flexCheckDefault" class="form-check-label text-truncate" value=""><%= task.name %>
+    <%= simple_form_for(task, data: {dashboard_mark_task_as_done_target:"form", action: "change->dashboard-mark-task-as-done#markAsDone"}) do |f| %>
+      <%= f.input :done, label: task.name, class: "form-check-input mb-0" %>
+    <% end %>
     <p class="task-description text-truncate"><%= task.description %></p>
   </div>
   <div class="task-status px-3">

--- a/app/views/users/_dashboard_task.html.erb
+++ b/app/views/users/_dashboard_task.html.erb
@@ -2,8 +2,8 @@
   <div class="form-check task-checkbox">
     <%# <input type="checkbox" class="form-check-input" value="" id="flexCheckDefault" data-action="change->dashboard-mark-task-as-done#markAsDone"> %>
     <%# <label for="flexCheckDefault" class="form-check-label text-truncate" value=""><%= task.name %>
-    <%= simple_form_for(task, data: {dashboard_mark_task_as_done_target:"form", action: "change->dashboard-mark-task-as-done#markAsDone"}) do |f| %>
-      <%= f.input :done, label: task.name, class: "form-check-input mb-0" %>
+    <%= simple_form_for(task, data: { action: "change->dashboard-mark-task-as-done#markAsDone"}) do |f| %>
+      <%= f.input :done, label: task.name, class: "form-check-input mb-0", data: { dashboard_mark_task_as_done_target:"input" } %>
     <% end %>
     <p class="task-description text-truncate"><%= task.description %></p>
   </div>

--- a/app/views/users/_dashboard_task.html.erb
+++ b/app/views/users/_dashboard_task.html.erb
@@ -1,11 +1,11 @@
-<div class="task-container m-3">
+<div class="task-container m-3 ">
   <div class="form-check task-checkbox">
-    <input type="checkbox" class="form-check-input" value="" id="flexCheckDefault">
+    <input type="checkbox" class="form-check-input" value="" id="flexCheckDefault" data-action="change->dashboard-mark-task-as-done#markAsDone">
     <label for="flexCheckDefault" class="form-check-label text-truncate" value=""><%= task.name %></label>
     <p class="task-description text-truncate"><%= task.description %></p>
   </div>
   <div class="task-status px-3">
-    <p class="m-0 task-status-badge <%= task.status %>"><%= task.status.capitalize %></p>
+    <p class="m-0 task-status-badge <%= task.status %>" data-dashboard-mark-task-as-done-target="status"><%= task.status.capitalize %></p>
   </div>
   <div class="task-due-date px-3">
     <% if task.end %>

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -14,7 +14,7 @@
   <div class="row mx-3 justify-content-center">
     <div class="dashboard-events-container col-10 p-3">
       <div class="dashboard-events-headers pe-5 ps-4 py-3">
-        <h2 class="">Events</h2>
+        <h2 class="">Events <span class="dashboard-events-count">(<%= @events.where(event_status: "upcoming").count %> upcoming)</span></h2>
         <%= link_to 'Create Event', new_event_path, class: "brand-btn" %>
       </div>
       <div class="dashboard-events-inner-container">

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -2,7 +2,7 @@
   <div class="row mx-3 justify-content-center  mb-3">
     <div class="dashboard-tasks-container col-10 p-3">
       <div class="dashboard-tasks-headers ps-3">
-        <h2 class="">Tasks</h2>
+        <h2 class="">Tasks <span class="dashboard-tasks-count">(<%= @tasks.where(status: "pending").count %> remaining)</span></h2>
       </div>
       <div class="dashboard-tasks-inner-container">
         <% @tasks.each do |task| %>

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -4,7 +4,7 @@
       <div class="dashboard-tasks-headers ps-3">
         <h2 class="">Tasks <span class="dashboard-tasks-count">(<%= @tasks.where(status: "pending").count %> remaining)</span></h2>
       </div>
-      <div class="dashboard-tasks-inner-container">
+      <div class="dashboard-tasks-inner-container" data-controller="dashboard-mark-task-as-done">
         <% @tasks.each do |task| %>
           <%= render 'dashboard_task', task: task %>
         <% end %>


### PR DESCRIPTION
Dashboard now lets you mark a task as done.
When it is checked, it is removed from the remaining tasks list - and updated in the db - so should be updated in the actual event's tasks tab.
Also, if you un-check the task in the event's task tab, the task will re-appear in the dashboard list with the updated status of 'pending'

![Screen Shot 2022-08-30 at 11 09 40](https://user-images.githubusercontent.com/76161172/187332884-6adc09a1-a89b-4eb5-9bc7-5939025a4846.png)
