### PR TITLE
Add promo materials section to events main

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -14,3 +14,6 @@
 @import "logo_top_left";
 @import "messages";
 @import "tabbar";
+@import "main_timetable";
+@import "main_files";
+@import "main_gear";

--- a/app/assets/stylesheets/components/_main.scss
+++ b/app/assets/stylesheets/components/_main.scss
@@ -96,6 +96,6 @@
 }
 
 // To turn off hover effects on the Timetable, Gear, etc.
-.noHover {
-  pointer-events: none;
-}
+// .noHover {
+//   pointer-events: none;
+// }

--- a/app/assets/stylesheets/components/_main.scss
+++ b/app/assets/stylesheets/components/_main.scss
@@ -94,3 +94,8 @@
   color: #999;
   text-transform: uppercase;
 }
+
+// To turn off hover effects on the Timetable, Gear, etc.
+.noHover {
+  pointer-events: none;
+}

--- a/app/assets/stylesheets/components/_main_files.scss
+++ b/app/assets/stylesheets/components/_main_files.scss
@@ -15,9 +15,18 @@
   padding: 16px;
 }
 
-.event-file {
+.event-file-container {
   height: 320px;
-  background-color: $light-purple;
+  background-color: $dark-gray;
+  border-radius: 5px;
+  padding: 24px;
+  overflow: hidden;
+}
+
+.event-file {
+  height: 100%;
+  width: 100%;
+  object-fit: contain;
 }
 
 .files-form-container {

--- a/app/assets/stylesheets/components/_main_files.scss
+++ b/app/assets/stylesheets/components/_main_files.scss
@@ -1,0 +1,32 @@
+.container-files {
+
+  background-color: $medium-gray;
+  border-radius: 4px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+  padding: 16px;
+}
+
+.container-files-media {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: 1fr;
+  gap: 24px;
+  padding: 16px;
+}
+
+.event-file {
+  height: 320px;
+  background-color: $light-purple;
+}
+
+.files-form-container {
+  padding: 24px;
+  padding-top: 36px;
+  color: $light-purple;
+  // grid-column-start: 1;
+  // grid-column-end: span 2;
+  // grid-row-start: 1;
+  // grid-row-end: 1;
+  text-align: center;
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -42,6 +42,13 @@ class EventsController < ApplicationController
     end
   end
 
+  def update
+    @event = Event.find(params[:id])
+    @event.update(event_params)
+    authorize @event
+    redirect_to event_path(@event)
+  end
+
   private
 
   def event_params

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -45,7 +45,7 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:name, :location, :start_date, :end_date, :photo, :poster_url, event_members_attributes: [:permission, :role, :user_id])
+    params.require(:event).permit(:name, :location, :start_date, :end_date, :photo, :poster_url, event_members_attributes: [:permission, :role, :user_id], files: [])
   end
 
   def build_event_members

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,7 @@ class Event < ApplicationRecord
   accepts_nested_attributes_for :event_members
   has_many :users, through: :event_members
   has_one_attached :photo
+  has_many_attached :files
 
   validates :location, presence: true
   validates :start_date, presence: true

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -18,4 +18,8 @@ class EventPolicy < ApplicationPolicy
   def create?
     true
   end
+
+  def update?
+    record.event_members.find_by(user: user)
+  end
 end

--- a/app/views/components/_timetable_set.html.erb
+++ b/app/views/components/_timetable_set.html.erb
@@ -1,5 +1,5 @@
-<div class="subtask-container" data-tasks-target="subtasks">
+<div class="subtask-container ms-5 my-3" data-tasks-target="subtasks">
   <% task.tasks.each do |task| %>
-    <p class="ms-5"><%= task.name %></p>
+    <p class=""><%= task.name %></p>
   <% end %>
 </div>

--- a/app/views/components/_timetable_set_form.html.erb
+++ b/app/views/components/_timetable_set_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for([event, parent_task, Task.new],
-  data: {tasks_target: "subtaskform", action: "submit->tasks#addSubtask"}
+  data: {tasks_target: "subtaskform", action: "submit->tasks#addSubtask"}, class: "mt-5"
 ) do |f| %>
-  <%= f.input :name %>
+  <%= f.input :name, label: "Add Set Time & Artist Name:", input_html: { class: " text-light"} %>
   <%= f.input :category, as: :hidden, input_html: {value: parent_task.category} %>
   <%= f.input :start, as: :hidden, input_html: {value: parent_task.start} %>
   <%= f.input :task, as: :hidden, input_html: {value: parent_task.task} %>

--- a/app/views/shared/_main.html.erb
+++ b/app/views/shared/_main.html.erb
@@ -70,17 +70,18 @@
 <div class="container-fluid">
   <div class="container-files mb-3">
     <div class="container-files-media">
-      <div class="event-file">
-      </div>
-      <div class="event-file">
-      </div>
-      <div class="event-file">
-      </div>
+      <% if event.files.attached? %>
+        <% event.files.each do |file| %>
+          <div class="event-file-container">
+            <%= cl_image_tag(file.key, class: "event-file")  %>
+          </div>
+        <% end %>
+      <% end %>
     </div>
     <div class="files-form-container">
       <%= simple_form_for(event) do |f| %>
-        <%= f.input :files, label: "Upload Media Here:" %>
-        <%= f.button :submit, class: "brand-btn" %>
+        <%= f.input :files, label: "Choose files to upload:", input_html: {multiple: true, class: "text-light"} %>
+        <%= f.button :submit, 'Upload', class: "brand-btn col-12" %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/_main.html.erb
+++ b/app/views/shared/_main.html.erb
@@ -50,7 +50,7 @@
     <div class="col-12">
       <div>
         <%# Gear Card  %>
-        <h2 class="event-task-container d-flex flex-column align-self-stretch">Gear</h2>
+        <h2 class="event-task-container d-flex flex-column align-self-stretch">GEAR</h2>
         <hr>
         <p>
           ▶︎3F(2ブース)<br>
@@ -65,10 +65,38 @@
         </p>
       </div>
     </div>
+    <div class="col-12">
+      <div>
+        <h2 class="event-task-container d-flex flex-column align-self-stretch">MISC</h2>
+        <hr>
+        <p>
+          ≪≪LIVEPAINT≫≫<br>
+          YSK<br>
+          KSK<br>
+          拓磨クワン<br>
+          AKIKO ASANO<br>
+          <br>
+          ≪VJ≫<br>
+          鎖国ちゃん<br>
+          <br>
+          ≪DECORATION≫<br>
+          FOREHEAD凸<br>
+          <br>
+          ≪LASERS≫<br>
+          前髪野瑠璃子<br>
+          <br>
+          ≪FOOD≫<br>
+          日の出タコス<br>
+          共振異空間住居阿波座ハウス<br>
+          たんぽぽ食堂<br>
+        </p>
+      </div>
+    </div>
   </div>
 </div>
 <div class="container-fluid">
   <div class="container-files mb-3">
+    <h2 class="">PROMOTIONAL MATERIALS</h2>
     <div class="container-files-media">
       <% if event.files.attached? %>
         <% event.files.each do |file| %>

--- a/app/views/shared/_main.html.erb
+++ b/app/views/shared/_main.html.erb
@@ -39,7 +39,7 @@
     </div>
   </div>
 </div>
-<div class="container-fluid mb-5">
+<div class="container-fluid noHover">
   <div class="info">
     <div class="col-12">
       <%# <h2 class="text-white align-self-center">Timetable</h2> %>

--- a/app/views/shared/_main.html.erb
+++ b/app/views/shared/_main.html.erb
@@ -67,7 +67,21 @@
     </div>
   </div>
 </div>
-<div class="contianer-fluid mb-5">
-  <div class="container-main">
+<div class="container-fluid">
+  <div class="container-files mb-3">
+    <div class="container-files-media">
+      <div class="event-file">
+      </div>
+      <div class="event-file">
+      </div>
+      <div class="event-file">
+      </div>
+    </div>
+    <div class="files-form-container">
+      <%= simple_form_for(event) do |f| %>
+        <%= f.input :files, label: "Upload Media Here:" %>
+        <%= f.button :submit, class: "brand-btn" %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_main.html.erb
+++ b/app/views/shared/_main.html.erb
@@ -47,5 +47,12 @@
         <%= render 'shared/main_timetable', event: event, task: task %>
       <% end %>
     </div>
+    <div class="col-12">
+      <%# Gear Card  %>
+    </div>
+  </div>
+</div>
+<div class="contianer-fluid mb-5">
+  <div class="container-main">
   </div>
 </div>

--- a/app/views/shared/_main.html.erb
+++ b/app/views/shared/_main.html.erb
@@ -39,7 +39,7 @@
     </div>
   </div>
 </div>
-<div class="container-fluid noHover">
+<div class="container-fluid ">
   <div class="info">
     <div class="col-12">
       <%# <h2 class="text-white align-self-center">Timetable</h2> %>

--- a/app/views/shared/_main.html.erb
+++ b/app/views/shared/_main.html.erb
@@ -48,7 +48,22 @@
       <% end %>
     </div>
     <div class="col-12">
-      <%# Gear Card  %>
+      <div>
+        <%# Gear Card  %>
+        <h2 class="event-task-container d-flex flex-column align-self-stretch">Gear</h2>
+        <hr>
+        <p>
+          ▶︎3F(2ブース)<br>
+          DJM900nxs2<br>
+          CDJ2000nxs×4<br>
+          Z2<br>
+          SL1200MK3D×2<br>
+          ▶︎4F<br>
+          DJM900nxs<br>
+          CDJ2000×2<br>
+          PLX1000×2<br>
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/shared/_main_timetable.html.erb
+++ b/app/views/shared/_main_timetable.html.erb
@@ -2,29 +2,17 @@
   <%= render 'shared/new_member_form_modal', event_task: task %>
   <div class="event-task-header d-flex justify-content-between align-items-center">
     <div class="card-body fs-4 d-flex align-items-center flex-grow-2">
-      <%# <%= render 'components/update_task_form', event: event, task: task %>
-      <%# <input type="checkbox" class="task-checkbox me-2" checked disabled> %>
-      <h3 class="timetable-header info-title" data-action="click->tasks#toggleDisplay stretched-link"><%= task.name %></h3>
+      <h3 class="timetable-header info-title" data-action="click->tasks#toggleDisplay stretched-link"><%= task.name.upcase %></h3>
     </div>
-    <%# Deleted Small task members avatars %>
-    <%# <div class="task-info d-flex flex-column justify-content-end align-items-end"> %>
-    <%# Deleted 'Done' and 'Pending' badge %>
-    <%# Deleted 'Category' badge  %>
-    <%# </div> %>
   </div>
-  <%# Task card expanded view %>
   <div class="d-flex flex-column card-content" data-tasks-target='task'>
     <hr>
-    <%# Deleted 'Category' badge  %>
-    <%# Deleted 'Description'  %>
-    <%# Subtasks %>
-    <%= render 'components/timetable_set', task: task %>
-    <%= render 'components/timetable_set_form', event: event, parent_task: task %>
-    <%# Subtasks end %>
     <p class='m-0 task-date'><i class="fa-solid fa-calendar-days me-1"></i>From: <%= task.start.strftime("%d.%m.%Y") %></p>
     <% if  task.end %>
-      <p class='m-0 task-date'><i class="fa-solid fa-calendar-days me-1"></i>End: <%= task.end.strftime("%d.%m.%Y") %></p>
+      <p class='m-0 task-date'><i class="fa-solid fa-calendar-days me-1 mb-3"></i>End: <%= task.end.strftime("%d.%m.%Y") %></p>
     <% end %>
+    <%= render 'components/timetable_set', task: task %>
+    <%= render 'components/timetable_set_form', event: event, parent_task: task %>
     <hr>
     <div class="task-members d-flex gap-1 justify-content-end align-items-center">
       <%= link_to new_task_task_member_path(task),
@@ -39,5 +27,4 @@
       <% end %>
     </div>
   </div>
-  <%# Task card expanded view end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   get "/dashboard", to: "users#dashboard", as: :dashboard
   get "/calendar", to: "users#calendar", as: :calendar
-  resources :events, only: [:new, :create, :show] do
+  resources :events, only: [:new, :create, :show, :update] do
     resources :event_members, only: [:create]
     resources :tasks, only: [:new, :create] do
       resources :tasks, only: [:create]


### PR DESCRIPTION
Theres now a promotional materials section where you can upload multiple files at a time.
*** Only upload what you want displayed - it will overwrite whatever was there each time you upload something.
Timetable is also functioning again with better styling and labels. This will all be filled in manually before pitch.
Placeholder sections for Gear and Misc are also added with data - will work to make these match Timetable from now.
<img width="1436" alt="Screen Shot 2022-08-31 at 22 56 37" src="https://user-images.githubusercontent.com/76161172/187696182-10078c27-f5dc-4d70-9096-b197b3ae42d5.png">
<img width="1436" alt="Screen Shot 2022-08-31 at 22 57 05" src="https://user-images.githubusercontent.com/76161172/187696304-27b8433f-b2ac-4fcb-9a8c-041f899932a6.png">
