### PR TITLE
Fixed Event create bug + Banner image issues

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/create_member_modal' %>
 <div class="container-fluid">
-  <div class="banner" style="background-image: url('<%= @event.photo.attached? ? cl_image_path(@event.photo.key) : @event.poster_url %>')">
+  <div class="banner" style="background-image: url('<%= @event.photo.attached? ? cl_image_path(@event.photo.key, :flags=>"ignore_aspect_ratio", :height=>160, :crop=>"scale") : @event.poster_url %>')">
     <div>
       <h1><%= @event.name %></h1>
     </div>

--- a/app/views/shared/_main_timetable.html.erb
+++ b/app/views/shared/_main_timetable.html.erb
@@ -6,10 +6,6 @@
     </div>
   </div>
   <div class="d-flex flex-column card-content" data-tasks-target='task'>
-    <p class='m-0 gear-time-date-start'><i class="fa-solid fa-calendar-days me-1"></i>From: <%= task.start.strftime("%d.%m.%Y") %></p>
-    <% if  task.end %>
-      <p class='m-0 gear-time-date-end'><i class="fa-solid fa-calendar-days me-1 mb-3"></i>End: <%= task.end.strftime("%d.%m.%Y") %></p>
-    <% end %>
     <%= render 'components/timetable_set', task: task %>
     <%= render 'components/timetable_set_form', event: event, parent_task: task %>
     <hr>

--- a/app/views/users/_dashboard_event.html.erb
+++ b/app/views/users/_dashboard_event.html.erb
@@ -1,5 +1,5 @@
 <%= link_to event_path(event), class: "event-link-container" do %>
-  <div class="event-container m-3" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= event.photo.attached? ? cl_image_path(event.photo.key, :flags=>"ignore_aspect_ratio", :height=>160, :crop=>"scale") : event.poster_url %>')  center no-repeat">
+  <div class="event-container m-3" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= event.photo.attached? ? cl_image_path(event.photo.key, :flags=>"ignore_aspect_ratio", :width=>1145, :height=>160, :crop=>"scale") : event.poster_url %>')  center no-repeat">
     <div class="left">
       <h3><%= event.name %></h3>
       <p><%= event.location %></p>

--- a/app/views/users/_dashboard_event.html.erb
+++ b/app/views/users/_dashboard_event.html.erb
@@ -1,11 +1,11 @@
 <%= link_to event_path(event), class: "event-link-container" do %>
-  <div class="event-container m-3" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= event.photo.attached? ? cl_image_path(event.photo.key) : event.poster_url %>') center;">
+  <div class="event-container m-3" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= event.photo.attached? ? cl_image_path(event.photo.key, :flags=>"ignore_aspect_ratio", :height=>160, :crop=>"scale") : event.poster_url %>')  center no-repeat">
     <div class="left">
       <h3><%= event.name %></h3>
       <p><%= event.location %></p>
     </div>
     <div class="right">
-    <p><strong><%= event.event_members.where(user_id: current_user).first.role.capitalize %></strong></p>
+      <p><strong><%= event.event_members.where(user_id: current_user).first.role.capitalize %></strong></p>
       <div>
         <p><%= event.start_date.strftime('%A') %></p>
         <p><%= event.start_date.strftime('%B %d, %Y') %></p>

--- a/app/views/users/_dashboard_task.html.erb
+++ b/app/views/users/_dashboard_task.html.erb
@@ -16,7 +16,7 @@
     <% end %>
   </div>
   <%= link_to event_path(task.event), class: "text-decoration-none" do %>
-    <div class="container task-event" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= task.event.photo.attached? ? cl_image_path(task.event.photo.key) : task.event.poster_url %>') center;">
+    <div class="container task-event" style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= task.event.photo.attached? ? cl_image_path(task.event.photo.key, :flags=>"ignore_aspect_ratio", :height=>80, :width=>240, :crop=>"scale") : task.event.poster_url %>') center center;">
       <h5><%= task.event.name %></h5>
     </div>
   <% end %>

--- a/app/views/users/calendar.html.erb
+++ b/app/views/users/calendar.html.erb
@@ -9,7 +9,7 @@
           <%= date %>
           <% events.each do |event| %>
             <%= link_to event_path(event), class: "text-decoration-none" do %>
-              <div class="calendar-event d-flex justify-content-center align-items-center"  style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= event.photo.attached? ? cl_image_path(event.photo.key) : event.poster_url %>') center;">
+              <div class="calendar-event d-flex justify-content-center align-items-center"  style="background: linear-gradient(45deg, rgba(8, 42, 82, 0.3), rgba(8, 42, 82, 0.8)), url('<%= event.photo.attached? ? cl_image_path(event.photo.key, :flags=>"ignore_aspect_ratio", :height=>62, :width=>150, :crop=>"scale") : event.poster_url %>') center;">
                 <p><%= event.name %></p>
               </div>
             <% end %>


### PR DESCRIPTION
Finally fixed banner image issues - must use the cropped poster versions I give you.
Normal images will get distorted in the banners (we can fix this after demo day of course).

Also fixed the bug in creating and event.

We can decide in the morning if we like the cropped banner look or how it was before better.
Before (no crop):
![Screen Shot 2022-09-02 at 03 24 18](https://user-images.githubusercontent.com/76161172/187985965-68bfea6b-0209-4a36-ae72-2979e43c2b41.png)

Cropped (kind of bad examples because the Makoto ones are not cropped - therefore stretched:
![Screen Shot 2022-09-02 at 03 25 49](https://user-images.githubusercontent.com/76161172/187986208-18ae90ae-7d84-4e72-aa65-4200cb2117a6.png)


Its an easy fix to change the banners back to how they were so now worries if you prefer old way.
Noisia poster looks better this way though I think.

![Screen Shot 2022-09-02 at 03 28 10](https://user-images.githubusercontent.com/76161172/187986598-c0bd7011-18c8-4de6-a80d-2830ff2953db.png)
